### PR TITLE
Add GCB automation to publish image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM us-central1-docker.pkg.dev/cloud-workstations-images/predefined/code-oss:latest
+
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+RUN mkdir /models
+RUN cd /models && wget https://huggingface.co/TheBloke/Llama-2-13B-Ensemble-v5-GGUF/resolve/main/llama-2-13b-ensemble-v5.Q4_K_M.gguf
+RUN cd /models && wget https://huggingface.co/TheBloke/openinstruct-mistral-7B-GGUF/resolve/main/openinstruct-mistral-7b.Q4_K_M.gguf

--- a/README.md
+++ b/README.md
@@ -24,3 +24,44 @@ Try it out with the script (from the virtual env ^^):
 ```bash
 (.localllm) ./trylocal.py
 ```
+
+## Running cloud workstation
+
+Currently using:
+* e2-standard-32 (32 vCPU, 16 core, 128 GB memory)
+* `us-central1-docker.pkg.dev/cloud-workstations-images/predefined/code-oss:latest`
+
+## Image publishing
+
+GCB automation publishes to `us-central1-docker.pkg.dev/$PROJECT_ID/localllm`. Enable GCR
+(including image vulnerability scanning and provenance generation) and create the image
+repo with:
+
+```
+gcloud config set project $PROJECT_ID
+gcloud services enable \
+  container.googleapis.com \
+  containeranalysis.googleapis.com \
+  containerscanning.googleapis.com \
+  artifactregistry.googleapis.com
+
+gcloud artifacts repositories create localllm \
+  --location=us-central1 \
+  --repository-format=docker \
+  --project=$PROJECT_ID
+```
+
+The published image is called `us-central1-docker.pkg.dev/$PROJECT_ID/localllm/localllm-cw`.
+
+
+## TODO
+
+1. Grab the latest version of each model instead of hardcoding
+2. Any way to increase ulimit or limited by cloud workstations container?
+
+https://github.com/abetlen/llama-cpp-python/issues/254
+
+```
+INFO     image_tests:image_tests.py:27 warning: failed to mlock 92168192-byte buffer (after previously locking 0 bytes): Cannot allocate memory
+INFO     image_tests:image_tests.py:27 Try increasing RLIMIT_MLOCK ('ulimit -l' as root).
+```

--- a/README.md
+++ b/README.md
@@ -65,3 +65,6 @@ https://github.com/abetlen/llama-cpp-python/issues/254
 INFO     image_tests:image_tests.py:27 warning: failed to mlock 92168192-byte buffer (after previously locking 0 bytes): Cannot allocate memory
 INFO     image_tests:image_tests.py:27 Try increasing RLIMIT_MLOCK ('ulimit -l' as root).
 ```
+
+3. The base image has 176 vulnerabilities :( Running `apt full-upgrade` removed 15 only 🙃
+

--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -1,0 +1,13 @@
+substitutions:
+  _GCR_LOCATION: us-central1-docker.pkg.dev
+  _IMAGE_NAME: localllm/localllm-cw
+steps:
+  # Build and tag using commit sha
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '.', '-t', '${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${COMMIT_SHA}', '-f', 'Dockerfile']
+    dir: '.'
+  - name: '${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${COMMIT_SHA}'
+    entrypoint: python
+    args: ["/workspace/image_tests.py"]
+options:
+  machineType: E2_HIGHCPU_32

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,15 +12,6 @@ steps:
   # Push the container image to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
     args: ['push', '${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${COMMIT_SHA}']
-  # Generate SBOM for the image
-  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: bash
-    args:
-    - -c
-    - |
-      set -ex
-      gcloud artifacts sbom export \
-        --uri=${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${COMMIT_SHA}
 images:
 - ${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${COMMIT_SHA}
 options:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,28 @@
+substitutions:
+  _GCR_LOCATION: us-central1-docker.pkg.dev
+  _IMAGE_NAME: localllm/localllm-cw
+steps:
+  # Build and tag using commit sha
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '.', '-t', '${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${COMMIT_SHA}', '-f', 'Dockerfile']
+    dir: '.'
+  - name: '${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${COMMIT_SHA}'
+    entrypoint: python
+    args: ["/workspace/image_tests.py"]
+  # Push the container image to Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${COMMIT_SHA}']
+  # Generate SBOM for the image
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: bash
+    args:
+    - -c
+    - |
+      set -ex
+      gcloud artifacts sbom export \
+        --uri=${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${COMMIT_SHA}
+images:
+- ${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${COMMIT_SHA}
+options:
+  requestedVerifyOption: VERIFIED
+  machineType: E2_HIGHCPU_32

--- a/image_tests.py
+++ b/image_tests.py
@@ -1,0 +1,66 @@
+"""Test(s) to run from inside the built image
+"""
+import atexit
+import logging
+import openai
+import shlex
+import subprocess
+import sys
+import time
+import unittest
+
+
+HOST="0.0.0.0"
+PORT=8000
+LLAMA_MODEL= "/models/llama-2-13b-ensemble-v5.Q4_K_M.gguf"
+MISTRAL_MODEL= "/models/openinstruct-mistral-7b.Q4_K_M.gguf"
+COMMAND="python3 -m llama_cpp.server --model {} --host {} --port {}"
+
+
+def wait_for_llm(p):
+    while True:
+        if p.poll() != None:
+            return False
+        output = p.stdout.readline().decode("utf-8").rstrip()
+        if "Uvicorn running on" in output:
+            return True
+
+
+class TestLLMs(unittest.TestCase):
+    def test_llama(self):
+        self._test_llm(LLAMA_MODEL)
+
+    def test_mistral(self):
+        self._test_llm(MISTRAL_MODEL)
+
+    def _test_llm(self, model):
+        with subprocess.Popen(
+            shlex.split(COMMAND.format(model, HOST, PORT)),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT) as p:
+
+            # ensure the process is cleaned up even if interrupted
+            atexit.register(lambda: p.kill())
+            self.assertTrue(wait_for_llm(p))
+
+            client = openai.OpenAI(
+                api_key="foo",
+                base_url=f"http://{HOST}:{PORT}/v1",
+            )
+            chat_completion = client.chat.completions.create(
+                messages=[{
+                        "role": "user",
+                        "content": "Please write me a haiku about cats",
+                }],
+                model="",
+            )
+
+            p.kill()
+            self.assertNotEqual(0, len(chat_completion.choices))
+            print(chat_completion.choices[0].message.content)
+            # TODO: the mistral model did sometimes return empty content, this might have false negatives
+            self.assertNotEqual("", chat_completion.choices[0].message.content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Start building up an image that contains the local API server, use GCB triggering to build and publish it, and GCB automation to test the image.