### PR TITLE
Add support for download command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM us-central1-docker.pkg.dev/cloud-workstations-images/predefined/code-oss:la
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
+COPY llm-tool llm-tool
+RUN cd llm-tool && pip install .
+
+# hoisted on my petard (not actually using this dir now but still checking for it...)
 RUN mkdir /models
-RUN cd /models && wget https://huggingface.co/TheBloke/Llama-2-13B-Ensemble-v5-GGUF/resolve/main/llama-2-13b-ensemble-v5.Q4_K_M.gguf
-RUN cd /models && wget https://huggingface.co/TheBloke/openinstruct-mistral-7B-GGUF/resolve/main/openinstruct-mistral-7b.Q4_K_M.gguf
+
+RUN llm models download TheBloke/Llama-2-13B-Ensemble-v5-GGUF
+RUN llm models download TheBloke/openinstruct-mistral-7B-GGUF

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN pip install -r requirements.txt
 COPY llm-tool llm-tool
 RUN cd llm-tool && pip install .
 
-# hoisted on my petard (not actually using this dir now but still checking for it...)
-RUN mkdir /models
-
 RUN llm models download TheBloke/Llama-2-13B-Ensemble-v5-GGUF
 RUN llm models download TheBloke/openinstruct-mistral-7B-GGUF
+
+# Startup script will move downloaded models from root home cache to user's cache
+COPY workstation-startup.d/* /etc/workstation-startup.d/

--- a/README.md
+++ b/README.md
@@ -10,20 +10,28 @@ Run LLMs locally on Cloud Workstations. Uses:
 ```bash
 python3 -m venv ~/.localllm
 source ~/.localllm/bin/activate
+
+# Install the tools
 pip3 install -r requirements.txt
+pip3 install ./llm-tool/.
 
-wget https://huggingface.co/TheBloke/Llama-2-13B-Ensemble-v5-GGUF/resolve/main/llama-2-13b-ensemble-v5.Q4_K_M.gguf
-wget https://huggingface.co/TheBloke/openinstruct-mistral-7B-GGUF/resolve/main/openinstruct-mistral-7b.Q4_K_M.gguf
+# Download the models
+llm models download TheBloke/Llama-2-13B-Ensemble-v5-GGUF
+llm models download TheBloke/openinstruct-mistral-7B-GGUF
 
-python3 -m llama_cpp.server --model /models/llama-2-13b-ensemble-v5.Q4_K_M.gguf --host 0.0.0.0 --port 8000
-python3 -m llama_cpp.server --model /models/openinstruct-mistral-7b.Q4_K_M.gguf --host 0.0.0.0 --port 8001
+# Host the models (may need to change the snapshot)
+python3 -m llama_cpp.server --model ~/.cache/huggingface/hub/models--TheBloke--Llama-2-13B-Ensemble-v5-GGUF/snapshots/bf8533401b9eb46855690fb06920e1e5ddf2f7e2/llama-2-13b-ensemble-v5.Q4_K_M.gguf --host 0.0.0.0 --port 8000
+python3 -m llama_cpp.server --model ~/.cache/huggingface/hub/models--TheBloke--openinstruct-mistral-7B-GGUF/snapshots/0eda7ce8a5951a2839c32f0bf074eb21dd28ecd8/openinstruct-mistral-7b.Q4_K_M.gguf --host 0.0.0.0 --port 8001
+
+# Try out some queries
+./trylocal.py
 ```
 
-Try it out with the script (from the virtual env ^^):
+You can interact with the Open API interface (which will also all you to query the models)
+by visiting the `/docs` extenstion, e.g. for the above:
 
-```bash
-(.localllm) ./trylocal.py
-```
+* http://localhost:8000/docs
+* http://localhost:8001/docs
 
 ## Running cloud workstation
 
@@ -52,19 +60,3 @@ gcloud artifacts repositories create localllm \
 ```
 
 The published image is called `us-central1-docker.pkg.dev/$PROJECT_ID/localllm/localllm-cw`.
-
-
-## TODO
-
-1. Grab the latest version of each model instead of hardcoding
-2. Any way to increase ulimit or limited by cloud workstations container?
-
-https://github.com/abetlen/llama-cpp-python/issues/254
-
-```
-INFO     image_tests:image_tests.py:27 warning: failed to mlock 92168192-byte buffer (after previously locking 0 bytes): Cannot allocate memory
-INFO     image_tests:image_tests.py:27 Try increasing RLIMIT_MLOCK ('ulimit -l' as root).
-```
-
-3. The base image has 176 vulnerabilities :( Running `apt full-upgrade` removed 15 only 🙃
-

--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -13,9 +13,14 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '.', '-t', '${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${COMMIT_SHA}', '-f', 'Dockerfile']
     dir: '.'
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${COMMIT_SHA}']
   # Run tests on the image itself
   - name: '${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${COMMIT_SHA}'
-    entrypoint: python
-    args: ["/workspace/image_tests.py"]
+    script: |
+      set -xe
+      mkdir -p /builder/home/.cache/huggingface
+      mv /root/.cache/huggingface/* /builder/home/.cache/huggingface
+      python /workspace/image_tests.py
 options:
   machineType: E2_HIGHCPU_32

--- a/llm-tool/README.md
+++ b/llm-tool/README.md
@@ -23,6 +23,20 @@ llm models list
 
 ### Download a model from 🤗
 
+If you're using models from TheBloke we can make some assumptions about repo
+structure:
+
+```bash
+llm models download TheBloke/Llama-2-13B-Ensemble-v5-GGUF
+```
+
+If you want a different specific file in the repo or the repo you are using
+doesn't follow the same file naming, you can specify the file explicitly:
+
+```bash
+llm models download TheBloke/Llama-2-13B-Ensemble-v5-GGUF --filename llama-2-13b-ensemble-v5.Q4_K_S.gguf
+```
+
 ### Update a model from 🤗
 
 ### Remove a model

--- a/llm-tool/README.md
+++ b/llm-tool/README.md
@@ -5,7 +5,8 @@ server. Uses:
 * Quantized models from 🤗
 * [llama-cpp-python's webserver](https://github.com/abetlen/llama-cpp-python#web-server)
 
-Assumes that models are downloaded to `/models` and only supports `.gguf` files.
+Assumes that models are downloaded to `~/.cache/huggingface/hub/` (the default cache path
+used by https://github.com/huggingface/huggingface_hub) and only supports `.gguf` files.
 
 ## Install
 

--- a/llm-tool/llm.py
+++ b/llm-tool/llm.py
@@ -9,7 +9,9 @@ import modelserving
 
 @click.group()
 def cli():
-    pass
+    if not modelfiles.dir_exists():
+        click.echo(f"Model directory {modelfiles.MODEL_DIR} does not exist. Please create it.")
+        exit()
 
 
 @cli.group()

--- a/llm-tool/llm.py
+++ b/llm-tool/llm.py
@@ -8,26 +8,26 @@ import modelserving
 import modeldownload
 
 
+MODEL_STR = "\t{}:{}"
+
+
 @click.group()
 def cli():
     """Download and run local LLMs"""
-    if not modelfiles.dir_exists():
-        click.echo(f"Model directory {modelfiles.MODEL_DIR} does not exist. Please create it.")
-        exit(1)
 
 
 @cli.group()
 def models():
     """Interact with models on 🤗 and on disk"""
-    pass
 
 
 @models.command()
 def list():
-    m = modelfiles.list()
+    """List the locally cached models"""
+    m = modelfiles.list_models()
     click.echo(f"Models installed to {modelfiles.MODEL_DIR}...")
     for mm in m:
-        click.echo(f"\t{mm}")
+        click.echo(MODEL_STR.format(mm[0], mm[1]))
 
 
 @models.command()
@@ -57,7 +57,7 @@ def remove():
 
 @cli.group()
 def serving():
-    pass
+    """Serve models locally"""
 
 
 @serving.command()
@@ -72,10 +72,12 @@ def stop():
 
 @serving.command()
 def status():
-    m = modelserving.running_models(modelfiles.list())
+    """Return all the cached models currently running via llama_cpp.server
+    """
+    m = modelserving.running_models()
     if len(m) > 0:
         click.echo(f"Models in {modelfiles.MODEL_DIR} currently running...")
         for mm in m:
-            click.echo(f"\t{mm}")
+            click.echo(MODEL_STR.format(mm[0], mm[1]))
     else:
         click.echo("No models currently running.")

--- a/llm-tool/llm.py
+++ b/llm-tool/llm.py
@@ -5,17 +5,20 @@ import click
 
 import modelfiles
 import modelserving
+import modeldownload
 
 
 @click.group()
 def cli():
+    """Download and run local LLMs"""
     if not modelfiles.dir_exists():
         click.echo(f"Model directory {modelfiles.MODEL_DIR} does not exist. Please create it.")
-        exit()
+        exit(1)
 
 
 @cli.group()
 def models():
+    """Interact with models on 🤗 and on disk"""
     pass
 
 
@@ -28,8 +31,18 @@ def list():
 
 
 @models.command()
-def download():
-    click.echo("DOWNLOAD")
+@click.argument("repo_id")
+@click.option("--filename", default="",
+              help="The specific model file to download. Will assume 4 bit medium model if not provided")
+def download(repo_id, filename):
+    """Download model from REPO_ID at 🤗"""
+    filename = modeldownload.default_filename(repo_id) if not filename else filename
+    if not filename:
+        click.echo(f"Unable to determine filename to use for {repo_id}.")
+        exit(1)
+    click.echo(f"Downloading {filename} from {repo_id}")
+    path = modeldownload.download(repo_id, filename)
+    click.echo(f"Downloaded to {path}")
 
 
 @models.command()

--- a/llm-tool/modeldownload.py
+++ b/llm-tool/modeldownload.py
@@ -1,0 +1,35 @@
+"""Downloads models from 🤗
+"""
+import huggingface_hub
+
+
+# Defaulting to 4 bit medium quantization
+DEFAULT_QUANT = "Q4_K_M"
+DEFAULT_FILE_EXT = "gguf"
+
+
+def default_filename(repo_id):
+    """Returns the default file to look for in that 🤗 repo
+
+    Naming doesn't seem to be consistent across 🤗 but it does seem
+    to be consistent across TheBloke's repos, so making some assumptions.
+    """
+    parts = repo_id.split("/")
+    if len(parts) != 2:
+        return ""
+    model_parts = parts[1].lower().split("-")
+    if model_parts[-1] != DEFAULT_FILE_EXT:
+        return ""
+    model = "-".join(model_parts[:-1])
+    return ".".join([model, DEFAULT_QUANT, DEFAULT_FILE_EXT])
+
+
+def download(path, filename):
+    """Downloads file from the path at 🤗
+
+    Uses huggingface_hub library to create a cache.
+    """
+    return huggingface_hub.hf_hub_download(
+        repo_id=path,
+        filename=filename,
+    )

--- a/llm-tool/modeldownload.py
+++ b/llm-tool/modeldownload.py
@@ -2,10 +2,11 @@
 """
 import huggingface_hub
 
+import modelfiles
+
 
 # Defaulting to 4 bit medium quantization
 DEFAULT_QUANT = "Q4_K_M"
-DEFAULT_FILE_EXT = "gguf"
 
 
 def default_filename(repo_id):
@@ -18,10 +19,10 @@ def default_filename(repo_id):
     if len(parts) != 2:
         return ""
     model_parts = parts[1].lower().split("-")
-    if model_parts[-1] != DEFAULT_FILE_EXT:
+    if model_parts[-1] != modelfiles.DEFAULT_FILE_EXT:
         return ""
     model = "-".join(model_parts[:-1])
-    return ".".join([model, DEFAULT_QUANT, DEFAULT_FILE_EXT])
+    return ".".join([model, DEFAULT_QUANT, modelfiles.DEFAULT_FILE_EXT])
 
 
 def download(path, filename):

--- a/llm-tool/modelfiles.py
+++ b/llm-tool/modelfiles.py
@@ -7,6 +7,14 @@ MODEL_DIR = "/models"
 SUPPORTED_EXTS = [".gguf"]
 
 
+def dir_exists():
+    """
+    Returns true if the model directory exists
+    """
+    return os.path.isdir(MODEL_DIR)
+
+
+
 def list():
     """
     List models downloaded to disk

--- a/llm-tool/modelserving.py
+++ b/llm-tool/modelserving.py
@@ -6,6 +6,9 @@ import psutil
 
 
 def running_models(models):
+    """
+    Returns a list of models that appear to be currently running
+    """
     procs = [proc.cmdline() for proc in psutil.process_iter([])]
     running = []
     for model in models:
@@ -15,6 +18,9 @@ def running_models(models):
 
 
 def is_running(model, processes):
+    """
+    Returns true if a python process is running the model
+    """
     for p in processes:
         if len(p) == 0:
             continue

--- a/llm-tool/modelserving.py
+++ b/llm-tool/modelserving.py
@@ -4,23 +4,22 @@ Uses https://github.com/abetlen/llama-cpp-python#web-server to serve models
 """
 import psutil
 
+import modelfiles
 
-def running_models(models):
+
+def running_models():
     """
     Returns a list of models that appear to be currently running
     """
     procs = [proc.cmdline() for proc in psutil.process_iter([])]
-    running = []
-    for model in models:
-        if is_running(model, procs):
-            running.append(model)
-    return running
+    return filter_running_models(procs)
 
 
-def is_running(model, processes):
+def filter_running_models(processes):
     """
-    Returns true if a python process is running the model
+    Returns the list of running models
     """
+    models = []
     for p in processes:
         if len(p) == 0:
             continue
@@ -29,6 +28,5 @@ def is_running(model, processes):
                 if arg == "--model":
                     if len(p) < i+2:
                         continue
-                    if model in p[i+1]:
-                        return True
-    return False
+                    models.append(modelfiles.model_from_path(p[i+1]))
+    return models

--- a/llm-tool/setup.py
+++ b/llm-tool/setup.py
@@ -3,11 +3,17 @@ from setuptools import setup
 setup(
     name='llm',
     version='0.0.1',
-    py_modules=['llm'],
+    py_modules=[
+        'llm',
+        'modeldownload',
+        'modelfiles',
+        'modelserving',
+    ],
     install_requires=[
         'Click',
         'llama-cpp-python[server]',
         'psutil',
+        'huggingface_hub'
     ],
     entry_points={
         'console_scripts': [

--- a/llm-tool/test_modeldownload.py
+++ b/llm-tool/test_modeldownload.py
@@ -1,0 +1,23 @@
+import unittest
+
+import modeldownload
+
+
+class TestModelDownload(unittest.TestCase):
+    def test_default_filename(self):
+        repo_id = "TheBloke/Llama-2-13B-Ensemble-v5-GGUF"
+        filename = modeldownload.default_filename(repo_id)
+        self.assertEqual("llama-2-13b-ensemble-v5.Q4_K_M.gguf", filename)
+
+    def test_default_filename_unknown_format(self):
+        filename = modeldownload.default_filename("foo")
+        self.assertEqual("", filename)
+
+    def test_default_filename_unsupported_ext(self):
+        repo_id = "TheBloke/openinstruct-mistral-7B-GPTQ"
+        filename = modeldownload.default_filename(repo_id)
+        self.assertEqual("", filename)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/llm-tool/test_modelfiles.py
+++ b/llm-tool/test_modelfiles.py
@@ -6,15 +6,32 @@ import modelfiles
 class TestModels(unittest.TestCase):
     def test_filter_models(self):
         files = [
-            "openinstruct-mistral-7b.Q4_K_M.gguf",
-            "foo.py",
-            "bar",
-            "some_dir/",
-            ".somedotfile",
+            "/home/user/.cache/huggingface/hub/models--TheBloke--Llama-2-13B-Ensemble-v5-GGUF/.no_exist/bf8533401b9eb46855690fb06920e1e5ddf2f7e2/tokenizer.model",
+            "/home/user/.cache/huggingface/hub/models--TheBloke--openinstruct-mistral-7B-GGUF/snapshots/0eda7ce8a5951a2839c32f0bf074eb21dd28ecd8/openinstruct-mistral-7b.Q4_K_M.gguf",
+            "/home/user/.cache/huggingface/hub/models--TheBloke--Llama-2-13B-Ensemble-v5-GGUF/snapshots/bf8533401b9eb46855690fb06920e1e5ddf2f7e2/config.json",
+            "/home/user/.cache/huggingface/hub/models--TheBloke--smartyplats-7B-v2-GGUF/refs/main"
+            "/home/user/.cache/huggingface/hub/models--TheBloke--smartyplats-7B-v2-GGUF/snapshots/b5c676eb555d1e44b5381969c7901d31add6673d/smartyplats-7b-v2.Q4_K_M.gguf",
         ]
         m = modelfiles.filter_models(files)
-        self.assertEqual(1, len(m))
-        self.assertEqual("openinstruct-mistral-7b.Q4_K_M.gguf", m[0])
+
+        self.assertEqual(2, len(m))
+        self.assertEqual("TheBloke/openinstruct-mistral-7B-GGUF", m[0][0])
+        self.assertEqual("openinstruct-mistral-7b.Q4_K_M.gguf", m[0][1])
+        self.assertEqual("TheBloke/smartyplats-7B-v2-GGUF", m[1][0])
+        self.assertEqual("smartyplats-7b-v2.Q4_K_M.gguf", m[1][1])
+
+
+    def test_model_from_path(self):
+        repo, model = modelfiles.model_from_path(
+            "/home/user/.cache/huggingface/hub/models--TheBloke--Llama-2-13B-Ensemble-v5-GGUF/snapshots/bf8533401b9eb46855690fb06920e1e5ddf2f7e2/llama-2-13b-ensemble-v5.Q4_K_M.gguf")
+        self.assertEqual("TheBloke/Llama-2-13B-Ensemble-v5-GGUF", repo)
+        self.assertEqual("llama-2-13b-ensemble-v5.Q4_K_M.gguf", model)
+
+
+    def test_model_from_path_unknown_format(self):
+        repo, model = modelfiles.model_from_path("foo")
+        self.assertEqual("", repo)
+        self.assertEqual("", model)
 
 
 if __name__ == "__main__":

--- a/llm-tool/test_modelserving.py
+++ b/llm-tool/test_modelserving.py
@@ -5,21 +5,23 @@ import modelserving
 
 class TestServing(unittest.TestCase):
     procs = [
-        ['/bin/bash', '/google/scripts/entrypoint.sh'],
-        ['/usr/bin/dockerd', '-p', '/var/run/docker.pid', '--data-root', '/home/.docker_data', '--mtu=1460'],
-        ['containerd', '--config', '/var/run/docker/containerd/containerd.toml'],
-        ['sh', './bin/codeoss-cloudworkstations', '--port=80', '--host=0.0.0.0'],
-        ['/opt/code-oss/node', '/opt/code-oss/out/bootstrap-fork', '--type=ptyHost', '--logsPath', '/home/user/.codeoss-cloudworkstations/data/logs/20231123T170240'],
-        ['python3', '-m', 'llama_cpp.server', '--model', '/models/llama-2-13b-ensemble-v5.Q4_K_M.gguf', '--host', '0.0.0.0', '--port', '8000'],
-        ['/bin/bash', '--init-file', '/opt/code-oss/out/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh'],
-        ['/bin/bash', '--init-file', '/opt/code-oss/out/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh'],
+        ["/bin/bash", "/google/scripts/entrypoint.sh"],
+        ["/usr/bin/dockerd", "-p", "/var/run/docker.pid", "--data-root", "/home/.docker_data", "--mtu=1460"],
+        ["containerd", "--config", "/var/run/docker/containerd/containerd.toml"],
+        ["sh", "./bin/codeoss-cloudworkstations", "--port=80", "--host=0.0.0.0"],
+        ["/opt/code-oss/node", "/opt/code-oss/out/bootstrap-fork", "--type=ptyHost", "--logsPath", "/home/user/.codeoss-cloudworkstations/data/logs/20231123T170240"],
+        ["python3", "-m", "llama_cpp.server", "--model",
+            "/home/user/.cache/huggingface/hub/models--TheBloke--Llama-2-13B-Ensemble-v5-GGUF/snapshots/bf8533401b9eb46855690fb06920e1e5ddf2f7e2/llama-2-13b-ensemble-v5.Q4_K_M.gguf",
+            "--host", "0.0.0.0", "--port", "8000"],
+        ["/bin/bash", "--init-file", "/opt/code-oss/out/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh"],
+        ["/bin/bash", "--init-file", "/opt/code-oss/out/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh"],
     ]
 
-    def test_is_running_running(self):
-        self.assertTrue(modelserving.is_running('llama-2-13b-ensemble-v5.Q4_K_M.gguf', self.procs))
-
-    def test_is_running_not_running(self):
-        self.assertFalse(modelserving.is_running('openinstruct-mistral-7b.Q4_K_M.gguf', self.procs))
+    def test_get_running_models(self):
+        models = modelserving.filter_running_models(self.procs)
+        self.assertEqual(1, len(models))
+        self.assertEqual("TheBloke/Llama-2-13B-Ensemble-v5-GGUF", models[0][0])
+        self.assertEqual("llama-2-13b-ensemble-v5.Q4_K_M.gguf", models[0][1])
 
 
 if __name__ == "__main__":

--- a/workstation-startup.d/011_move_llms.sh
+++ b/workstation-startup.d/011_move_llms.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# move the model files downloaded into the https://github.com/huggingface/huggingface_hub 
+# cache from the root user to the cloud workstation user
+# e.g. /root/.cache/huggingface/hub/models--TheBloke--Llama-2-13B-Ensemble-v5-GGUF/snapshots/bf8533401b9eb46855690fb06920e1e5ddf2f7e2/llama-2-13b-ensemble-v5.Q4_K_M.gguf 
+mkdir /home/user/.cache/
+mv /root/.cache/huggingface /home/user/.cache/
+chown -R user:user /home/user/.cache

--- a/workstation-startup.d/README.md
+++ b/workstation-startup.d/README.md
@@ -1,0 +1,8 @@
+# workstation-startup.d
+
+As described in [the cloud workstation docs](https://cloud.google.com/workstations/docs/customize-container-images#home_directory_modifications)
+modifications to the home directory should be done in start up scripts.
+
+We need to move the downloaded models from the root user cache to the user
+specific cache dir expected by https://github.com/huggingface/huggingface_hub
+once the user is created.


### PR DESCRIPTION
Using library from hugging face that I discovered while investigating
how FastChat interacts with hugging face. Comes with a nice progress
bar! Also does it's own caching in the user's directory which makes a
lot more sense than making a directory at /. Could eventually make this
cache configurable if we wanted to.

Fell down a rabbit hole for a while trying to see if we could just use
https://github.com/huggingface/transformers which FastChat uses and
seems to manage quite a bit more for us. For now just going to stick to
the simple version but might be worth investigating later.

Now that we're using the huggingface hub library, we can use the user's
local cache instead of a file in the root dir.

Also added the script required to setup the files properly for the
default user when using the built image with cloud workstations.